### PR TITLE
Upgrade zc.buildout to version that will not cause ValueError when ru…

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -20,7 +20,7 @@ always-checkout = true
 
 [versions]
 django = 1.4.10
-zc.buildout = 2.2.1
+zc.buildout = 2.3.1
 
 [sources]
 labgeeks-apollo = git git://github.com/abztrakt/labgeeks-apollo.git


### PR DESCRIPTION
…nning buildout. FIXES SDEV-610.
